### PR TITLE
Use github pages to serve website

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -22,8 +22,9 @@ jobs:
           GEOARROW_REF: "a7cc2392d3fb46e663d914d931f33d022dc45e91"
           GEOARROW_DATA_REF: "6416e472f18669bb7b7248714ecf3545d6a099cb"
 
-      - name: Publish to Netlify (and render)
+      - name: Publish to GitHub Pages (and render)
         uses: quarto-dev/quarto-actions/publish@v2
         with:
-          target: netlify
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+geoarrow.org

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,3 +36,6 @@ format:
     theme: cosmo
     css: styles.css
     toc: true
+
+resources:
+  - CNAME


### PR DESCRIPTION
We need to include the CNAME file in the built site that quarto is creating, ref https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/pull/61